### PR TITLE
objectproperteies: added configurable validation 

### DIFF
--- a/objectproperties/css/objectproperties.css
+++ b/objectproperties/css/objectproperties.css
@@ -3,4 +3,5 @@
 .ob_permissions { background: url(images/i_permissions.png) 5px 0 no-repeat; }
 .ob_no_permissions { background: url(images/i_permissions_deny.png) 5px 0 no-repeat; }
 .ob_grpi_author_auto { background: url(images/i_authors.png) no-repeat; }
-
+/* highlighting for filled tags */
+.aloha-op-button-isfilled { background-color: lightgreen; }

--- a/objectproperties/lib/objectproperties-plugin.js
+++ b/objectproperties/lib/objectproperties-plugin.js
@@ -1,171 +1,182 @@
 define([
-    'aloha/core',
-    'aloha/plugin',
-    'gcn/gcn-plugin',
-    'i18n!objectproperties/nls/i18n',
-    'i18n!aloha/nls/i18n',
-    'aloha/jquery',
-    'css!objectproperties/css/objectproperties.css'
-], function(Aloha,Plugin, GCNPlugin, i18n, i18nCore, $) {
-    'use strict';
-    
-    
-    var plugin;
+  'aloha/core',
+  'aloha/plugin',
+  'gcn/gcn-plugin',
+  'i18n!objectproperties/nls/i18n',
+  'i18n!aloha/nls/i18n',
+  'aloha/jquery',
+  'css!objectproperties/css/objectproperties.css'
+], function(Aloha, Plugin, GCNPlugin, i18n, i18nCore, $) {
+  'use strict';
 
-    var defaults = {
-        categories : [{
-            categoryname : "Objekteigenschaften",
-            tags : [{
-                                // "title" : "<b>Suche</b>: Vor interner Suche verstecken?",
-                                // "tag" : "object.uniqa_2015_notsearchable",
-                                // "cssclass" : "sidebarobject-uniqa_2015_notsearchable",
-                                // "checkProp": "check",
-                                // "checkPropValue": false
-            }]
-        }],
-        template : '<button data-tag="{tag}" class="{cssclass}">{title}</button>'
-    };
 
-    var taglist = [];
+  var plugin;
 
-    // update validation when clsoing tagfill
-    // compare and set/remove class "is-filled"
-    function validateTag($elem) {
-        // focus event is fired on tagfill close (gcn-plugin.js:715)
-        // handle this once
-        $('body').one('focus.objectpropertiesplugin', function (e) {
-            // get the page and tag obj after tagfill close to compare changes
-            var pageId = GCNPlugin.page.id();
-            GCN.page(pageId, function (page){
+  var defaults = {
+    categories: [{
+      categoryname: "Objekteigenschaften",
+      tags: [{
+        // "title" : "<b>Suche</b>: Vor interner Suche verstecken?",
+        // "tag" : "object.uniqa_2015_notsearchable",
+        // "cssclass" : "sidebarobject-uniqa_2015_notsearchable",
+        // "checkProp": "check",
+        // "checkPropValue": false
+      }]
+    }],
+    template: '<button data-tag="{tag}" class="{cssclass}">{title}</button>'
+  };
+
+  var taglist = [];
+
+  // update validation when clsoing tagfill
+  // compare and set/remove class "is-filled"
+  function validateTag($elem) {
+    // focus event is fired on tagfill close (gcn-plugin.js:715)
+    // handle this once
+    $('body').one('focus.objectpropertiesplugin', function(e) {
+      // get the page and tag obj after tagfill close to compare changes
+      var pageId = GCNPlugin.page.id();
+      GCN.page(pageId, function(page) {
         // get fresh tag object
         page.clear();
-        GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
-                    console.log('run validation for ', pageId, tag.prop('id'));
-                    // get part and value to compare from html (write to html before)
-                    if (tag.part($elem.attr("data-checkprop")).toString() !== $elem.attr("data-checkpropvalue")) {
-                        // add class
-                    $elem.addClass('aloha-op-button-isfilled');
-                    } else {
-                        // not filled - remove class "is-filled"
-                        $elem.removeClass('aloha-op-button-isfilled');
-                    }
+        GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag) {
+          console.log('run validation for ', pageId, tag.prop('id'));
+          // get part and value to compare from html (write to html before)
+          // check if select (contains selectedOptions)
+          var partToCheck = tag.part($elem.attr("data-checkprop"));
+          if (typeof partToCheck === "object" && partToCheck.hasOwnProperty('selectedOptions')) {
+              // this is a select-tagpart check if the selectedOptions property is an empty array ...
+              partToCheck = partToCheck.selectedOptions.toString();
+          }
+          if (partToCheck.toString() !== $elem.attr("data-checkpropvalue")) {
+            // add class
+            $elem.addClass('aloha-op-button-isfilled');
+          } else {
+            // not filled - remove class "is-filled"
+            $elem.removeClass('aloha-op-button-isfilled');
+          }
         });
-            });
-        });
-    }
+      });
+    });
+  }
 
-    function openTag($elem) {
-        var pageId = GCNPlugin.page.id();
-        GCN.page(pageId, function (page) {
-            page.tag($elem.attr("data-keyword"), function(tag){
-                //first we have to try to close any open tag fill
-                try {
-                    GCNPlugin.closeLightbox();
-                } catch(err) {
-                    //tag fill could not be closed because it was not open
-                }
-                //now we can open the desired object property as tag fill
-                console.log('opening tag fill for', pageId, tag.prop('id'));
-                // hook up validation
-                validateTag($elem); 
-                GCNPlugin.openTagFill(tag.prop('id'), pageId);
-            });
-        });
-    }
+  function openTag($elem) {
+    var pageId = GCNPlugin.page.id();
+    GCN.page(pageId, function(page) {
+      page.tag($elem.attr("data-keyword"), function(tag) {
+        //first we have to try to close any open tag fill
+        try {
+          GCNPlugin.closeLightbox();
+        } catch (err) {
+          //tag fill could not be closed because it was not open
+        }
+        //now we can open the desired object property as tag fill
+        console.log('opening tag fill for', pageId, tag.prop('id'));
+        // hook up validation
+        validateTag($elem);
+        GCNPlugin.openTagFill(tag.prop('id'), pageId);
+      });
+    });
+  }
 
-    /**
-     * This is a small templating function
-     */
-    function formatTemplate(template, obj) {
-        return template.replace(/{(\w+)}/g, function(match, keyword) { 
-            return typeof obj[keyword] != 'undefined'
-              ? obj[keyword]
-              : match
-            ;
-        });
-    }
-    
-    /**
-     * We want to use the sidebar too
-     * Have a look at http://www.aloha-editor.org/guides/sidebar.html
-     */
-    function prepareSidebar(sidebar) {
-        // add panel for each category
-        for (var j = 0; j < plugin._settings.categories.length; j++) {
-            sidebar.addPanel({
-                id: 'aloha-objectproperties-panel-' + plugin._settings.categories[j].categoryname,
-                title: plugin._settings.categories[j].categoryname,
-                expanded: true,
-                activeOn: true,
-                content: '<div id="aloha-objectproperties-panel-content-' + plugin._settings.categories[j].categoryname + '">\
+
+  /**
+   * This is a small templating function
+   */
+  function formatTemplate(template, obj) {
+    return template.replace(/{(\w+)}/g, function(match, keyword) {
+      return typeof obj[keyword] != 'undefined' ? obj[keyword] : match;
+    });
+  }
+
+  /**
+   * We want to use the sidebar too
+   * Have a look at http://www.aloha-editor.org/guides/sidebar.html
+   */
+  function prepareSidebar(sidebar) {
+    // add panel for each category
+    for (var j = 0; j < plugin._settings.categories.length; j++) {
+      sidebar.addPanel({
+        id: 'aloha-objectproperties-panel-' + plugin._settings.categories[j].categoryname,
+        title: plugin._settings.categories[j].categoryname,
+        expanded: true,
+        activeOn: true,
+        content: '<div id="aloha-objectproperties-panel-content-' + plugin._settings.categories[j].categoryname + '">\
                             <fieldset id="aloha-objectproperties-panel-buttoncontainer-' + plugin._settings.categories[j].categoryname + '">\
                             </fieldset>\
                           </div>',
-                onInit: function () {
+        onInit: function() {
+          var that = this;
 
-                    var pageId = GCNPlugin.page.id();
+          var pageId = GCNPlugin.page.id();
 
-                    // compare all page tags to the tags in our set
-                    GCN.page(pageId).tags(function(tags) {
-                        $(Aloha.settings.plugins.objectproperties.config).each( function (category) {
-                            var categoryname = this.categoryname;
-                            $(this.tags).each( function (){
-                                var display = false;
-                                var filled = false;
-                                for(var i = 0; i<tags.length; i++) {
-                                    if(this.tag === tags[i]._name) {
-                                        // Object Property shall be editable in sidebar
-                                        display = true;
-                                        // get container
-                                        var $buttoncontainer = $(this.content).find('#aloha-objectproperties-panel-buttoncontainer-' + categoryname);
-                                        $buttoncontainer.on('click', '.aloha-op-button', function(){
-                                            openTag($(this));
-                                        });
-                                        if (tags[i].part(this.checkProp) !== this.checkPropValue) {
-                                            filled = true;
-                                        }
-                                    }
-                                }
-                                if(display) {
-                                    var html = formatTemplate(plugin._settings.template, this);
-                                    var $button = $(html);
-                                    $button
-                                        .attr("data-keyword", this.tag)
-                                        // add validation info
-                                        .attr("data-checkprop", this.checkProp)
-                                        .attr("data-checkpropvalue", this.checkPropValue);
-                                    $button.addClass("aloha-op-button");
-                                    if(filled){
-                                        $button.addClass("aloha-op-button-isfilled");
-                                    }
-                                    $buttoncontainer.append($button);
-                                }
-                            });
-                        });
+          // compare all page tags to the tags in our set
+          GCN.page(pageId).tags(function(tags) {
+            $(Aloha.settings.plugins.objectproperties.config.categories).each(function(category) {
+              var categoryname = this.categoryname;
+              $(this.tags).each(function() {
+                var display = false;
+                var filled = false;
+                for (var i = 0; i < tags.length; i++) {
+                  if (this.tag === tags[i]._name) {
+                    // Object Property shall be editable in sidebar
+                    display = true;
+                    // get container
+                    var $buttoncontainer = $(that.content).find('#aloha-objectproperties-panel-buttoncontainer-' + categoryname);
+                    $buttoncontainer.on('click', '.aloha-op-button', function() {
+                      openTag($(this));
                     });
+                    // check if select (contains selectedOptions)
+                    var partToCheck = tags[i].part(this.checkProp);
+                    if (typeof partToCheck === "object" && partToCheck.hasOwnProperty('selectedOptions')) {
+                        // this is a select-tagpart check if the selectedOptions property is an empty array ...
+                        partToCheck = partToCheck.selectedOptions.toString();
+                    }
+                    if (partToCheck !== this.checkPropValue) {
+                      filled = true;
+                    }
+                  }
                 }
+                if (display) {
+                  var html = formatTemplate(plugin._settings.template, this);
+                  var $button = $(html);
+                  $button
+                    .attr("data-keyword", this.tag)
+                    // add validation info
+                    .attr("data-checkprop", this.checkProp)
+                    .attr("data-checkpropvalue", this.checkPropValue);
+                  $button.addClass("aloha-op-button");
+                  if (filled) {
+                    $button.addClass("aloha-op-button-isfilled");
+                  }
+                  $buttoncontainer.append($button);
+                }
+              });
             });
+          });
         }
-        sidebar.show();
+      });
     }
+    sidebar.show();
+  }
+
+  /**
+   * We create and return the plugin.
+   */
+  return Plugin.create('objectproperties', {
 
     /**
-     * We create and return the plugin.
+     * Configure the available languages
      */
-    return Plugin.create('objectproperties', {
-        
-        /**
-         * Configure the available languages
-         */
-        languages: ['en', 'de'],
+    languages: ['en', 'de'],
 
-        /**
-         * Initialize the plugin
-         */
-        init: function () {
-            plugin = this;
-            plugin._settings = $.extend({}, defaults, plugin.settings.config);
-            prepareSidebar(Aloha.Sidebar.right);
-        }
-    });
+    /**
+     * Initialize the plugin
+     */
+    init: function() {
+      plugin = this;
+      plugin._settings = $.extend({}, defaults, plugin.settings.config);
+      prepareSidebar(Aloha.Sidebar.right);
+    }
+  });
 });

--- a/objectproperties/lib/objectproperties-plugin.js
+++ b/objectproperties/lib/objectproperties-plugin.js
@@ -1,108 +1,156 @@
 define([
-	'aloha/core',
-	'aloha/plugin',
-	'gcn/gcn-plugin',
-	'i18n!objectproperties/nls/i18n',
-	'i18n!aloha/nls/i18n',
-	'aloha/jquery',
-	'css!objectproperties/css/objectproperties.css'
+    'aloha/core',
+    'aloha/plugin',
+    'gcn/gcn-plugin',
+    'i18n!objectproperties/nls/i18n',
+    'i18n!aloha/nls/i18n',
+    'aloha/jquery',
+    'css!objectproperties/css/objectproperties.css'
 ], function(Aloha,Plugin, GCNPlugin, i18n, i18nCore, $) {
-	'use strict';
-	
-	
-	var plugin;
+    'use strict';
+    
+    
+    var plugin;
 
-	var defaults = {
-		tags : {},
-		template : '<button data-tag="{tag}" class="{cssclass}">{title}</button>',
-		test : "test"
-	};
+    var defaults = {
+        // add tags which should be reachable in sidebar here
+        tags : {
+            // title: "Title, shown in sidebar",
+            // tag: "keyword of tag"
+            // cssclass: "set a individual class for each button"
+            // checkProp: "", // property of the tag to check if not equal to checkPropValue, i.e. "text"
+            // checkPropValue: "" // value compared to checkProp i.e. "" --> tagtype text(short): (tag.part("text") !== "")
+        },
+        // markup for buttons in sidebar
+        template : '<button data-tag="{tag}" class="{cssclass}">{title}</button>'
+    };
 
-	function openTag($elem) {
-		var pageId = GCNPlugin.page.id();
-		GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
-			//first we have to try to close any open tag fill
-			try {
-				GCNPlugin.closeLightbox();
-			} catch(err) {
-				//tag fill could not be closed because it was not open
-			}
-			//now we can open the desired object property as tag fill
-			console.log('opening tag fill for', pageId, tag.prop('id'));
-			GCNPlugin.openTagFill(tag.prop('id'), pageId);
-		});
-	}
+    // update validation when clsoing tagfill
+    // compare and set/remove class "is-filled"
+    function validateTag($elem) {
+        // focus event is fired on tagfill close (gcn-plugin.js:715)
+        // handle this once
+        $('body').one('focus.objectpropertiesplugin', function (e) {
+            // get the page and tag obj after tagfill close to compare changes
+            var pageId = GCNPlugin.page.id();
+            GCN.page(pageId, function (page) {
+                // get fresh tag object
+                page.clear();
+                GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
+                    console.log('run validation for ', pageId, tag.prop('id'));
+                    // get part and value to compare from html (write to html before)
+                    if (tag.part($elem.attr("data-checkprop")).toString() !== $elem.attr("data-checkpropvalue")) {
+                        // add class
+                        $elem.addClass('aloha-op-button-isfilled');
+                    } else {
+                        // not filled - remove class "is-filled"
+                        $elem.removeClass('aloha-op-button-isfilled');
+                    }
+                });
+            });
+        });
+    }
 
-	/**
-	 * This is a small templating function
-	 */
-	function formatTemplate(template, obj) {
-		return template.replace(/{(\w+)}/g, function(match, keyword) { 
-		    return typeof obj[keyword] != 'undefined'
-		      ? obj[keyword]
-		      : match
-		    ;
-		});
-	}
-	
-	/**
-	 * We want to use the sidebar too
-	 * Have a look at http://www.aloha-editor.org/guides/sidebar.html
-	 */
-	function prepareSidebar(sidebar) {
-		sidebar.addPanel({
-			id: 'aloha-objectproperties-panel',
-			title: i18n.t('sidebar.objectproperties.title'),
-			expanded: true,
-			activeOn: true,
-			content: '<div id="aloha-objectproperties-panel-content">\
-						<fieldset id="aloha-objectproperties-panel-buttoncontainer">\
-						</fieldset>\
-					  </div>',
-			onInit: function () {
-				var $buttoncontainer = $(this.content).find('#aloha-objectproperties-panel-buttoncontainer');
-				$buttoncontainer.on('click', '.aloha-op-button', function(){
-					openTag($(this));
-				});
-				var pageId = GCNPlugin.page.id();
+    function openTag($elem) {
+        var pageId = GCNPlugin.page.id();
+        GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
+            //first we have to try to close any open tag fill
+            try {
+                GCNPlugin.closeLightbox();
+            } catch(err) {
+                //tag fill could not be closed because it was not open
+            }
+            //now we can open the desired object property as tag fill
+            console.log('opening tag fill for', pageId, tag.prop('id'));
+            // hook up validation
+            validateTag($elem); 
+            GCNPlugin.openTagFill(tag.prop('id'), pageId);
+        });
+    }
 
-				GCN.page(pageId).tags(function(tags) {
-					$(plugin._settings.tags).each(function(){
-						var display = false;
-						for(var i = 0; i<tags.length; i++) {
-							if(this.tag === tags[i]._name) display = true;
-						}
-						if(display) {
-							var html = formatTemplate(plugin._settings.template, this);
-							var $button = $(html);
-							$button.attr("data-keyword", this.tag);
-							$button.addClass("aloha-op-button");
-							$buttoncontainer.append($button);
-						}
-					});
-				});
-			}
-		});
-		sidebar.show();
-	}
+    /**
+     * This is a small templating function
+     */
+    function formatTemplate(template, obj) {
+        return template.replace(/{(\w+)}/g, function(match, keyword) { 
+            return typeof obj[keyword] != 'undefined'
+              ? obj[keyword]
+              : match
+            ;
+        });
+    }
+    
+    /**
+     * We want to use the sidebar too
+     * Have a look at http://www.aloha-editor.org/guides/sidebar.html
+     */
+    function prepareSidebar(sidebar) {
+        sidebar.addPanel({
+            id: 'aloha-objectproperties-panel',
+            title: i18n.t('sidebar.objectproperties.title'),
+            expanded: true,
+            activeOn: true,
+            content: '<div id="aloha-objectproperties-panel-content">\
+                        <fieldset id="aloha-objectproperties-panel-buttoncontainer">\
+                        </fieldset>\
+                      </div>',
+            onInit: function () {
+                var $buttoncontainer = $(this.content).find('#aloha-objectproperties-panel-buttoncontainer');
+                $buttoncontainer.on('click', '.aloha-op-button', function(){
+                    openTag($(this));
+                });
+                var pageId = GCNPlugin.page.id();
 
-	/**
-	 * We create and return the plugin.
-	 */
+                GCN.page(pageId).tags(function(tags) {
+                    $(plugin._settings.tags).each(function(){
+                        var display = false;
+                        var filled = false;
+                        for(var i = 0; i<tags.length; i++) {
+                            if(this.tag === tags[i]._name) {
+                                display = true;
+                                if (tags[i].part(this.checkProp) !== this.checkPropValue) {
+                                    filled = true;
+                                }
+                            }
+                        }
+                        if(display) {
+                            var html = formatTemplate(plugin._settings.template, this);
+                            var $button = $(html);
+                            $button
+                                .attr("data-keyword", this.tag)
+                                // add validation info
+                                .attr("data-checkprop", this.checkProp)
+                                .attr("data-checkpropvalue", this.checkPropValue);
+                            $button.addClass("aloha-op-button");
+                            if(filled){
+                                $button.addClass("aloha-op-button-isfilled");
+                            }
+                            $buttoncontainer.append($button);
+                        }
+                    });
+                });
+            }
+        });
+        sidebar.show();
+    }
+
+    /**
+     * We create and return the plugin.
+     */
     return Plugin.create('objectproperties', {
-		
-		/**
-		 * Configure the available languages
-		 */
-		languages: ['en', 'de'],
+        
+        /**
+         * Configure the available languages
+         */
+        languages: ['en', 'de'],
 
-		/**
-		 * Initialize the plugin
-		 */
-		init: function () {
-			plugin = this;
-			plugin._settings = $.extend({}, defaults, plugin.settings.config);
-			prepareSidebar(Aloha.Sidebar.right);
-		}
-	});
+        /**
+         * Initialize the plugin
+         */
+        init: function () {
+            plugin = this;
+            plugin._settings = $.extend({}, defaults, plugin.settings.config);
+            prepareSidebar(Aloha.Sidebar.right);
+        }
+    });
 });

--- a/objectproperties/lib/objectproperties-plugin.js
+++ b/objectproperties/lib/objectproperties-plugin.js
@@ -29,7 +29,7 @@ define([
     // compare and set/remove class "is-filled"
     function validateTag($elem) {
         // check if validation config is set
-        if(tags[i].part(this.checkProp) !== null) {
+        if($elem.attr('data-checkprop') !== undefined) {
         // focus event is fired on tagfill close (gcn-plugin.js:715)
         // handle this once
         $('body').one('focus.objectpropertiesplugin', function (e) {
@@ -112,7 +112,7 @@ define([
                             if(this.tag === tags[i]._name) {
                                 display = true;
                                 // check if validation config is set
-                                if(tags[i].part(this.checkProp) !== null) {
+                                if(this.hasOwnProperty('checkProp')) {
                                     if (tags[i].part(this.checkProp) !== this.checkPropValue) {
                                         filled = true;
                                     }

--- a/objectproperties/lib/objectproperties-plugin.js
+++ b/objectproperties/lib/objectproperties-plugin.js
@@ -28,27 +28,30 @@ define([
     // update validation when clsoing tagfill
     // compare and set/remove class "is-filled"
     function validateTag($elem) {
+        // check if validation config is set
+        if(tags[i].part(this.checkProp) !== null) {
         // focus event is fired on tagfill close (gcn-plugin.js:715)
         // handle this once
         $('body').one('focus.objectpropertiesplugin', function (e) {
-            // get the page and tag obj after tagfill close to compare changes
-            var pageId = GCNPlugin.page.id();
-            GCN.page(pageId, function (page) {
-                // get fresh tag object
-                page.clear();
-                GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
-                    console.log('run validation for ', pageId, tag.prop('id'));
-                    // get part and value to compare from html (write to html before)
-                    if (tag.part($elem.attr("data-checkprop")).toString() !== $elem.attr("data-checkpropvalue")) {
-                        // add class
-                        $elem.addClass('aloha-op-button-isfilled');
-                    } else {
-                        // not filled - remove class "is-filled"
-                        $elem.removeClass('aloha-op-button-isfilled');
-                    }
+                // get the page and tag obj after tagfill close to compare changes
+                var pageId = GCNPlugin.page.id();
+                GCN.page(pageId, function (page) {
+                    // get fresh tag object
+                    page.clear();
+                    GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
+                        console.log('run validation for ', pageId, tag.prop('id'));
+                        // get part and value to compare from html (write to html before)
+                        if (tag.part($elem.attr("data-checkprop")).toString() !== $elem.attr("data-checkpropvalue")) {
+                            // add class
+                            $elem.addClass('aloha-op-button-isfilled');
+                        } else {
+                            // not filled - remove class "is-filled"
+                            $elem.removeClass('aloha-op-button-isfilled');
+                        }
+                    });
                 });
             });
-        });
+        }
     }
 
     function openTag($elem) {
@@ -108,8 +111,11 @@ define([
                         for(var i = 0; i<tags.length; i++) {
                             if(this.tag === tags[i]._name) {
                                 display = true;
-                                if (tags[i].part(this.checkProp) !== this.checkPropValue) {
-                                    filled = true;
+                                // check if validation config is set
+                                if(tags[i].part(this.checkProp) !== null) {
+                                    if (tags[i].part(this.checkProp) !== this.checkPropValue) {
+                                        filled = true;
+                                    }
                                 }
                             }
                         }

--- a/objectproperties/lib/objectproperties-plugin.js
+++ b/objectproperties/lib/objectproperties-plugin.js
@@ -13,61 +13,63 @@ define([
     var plugin;
 
     var defaults = {
-        // add tags which should be reachable in sidebar here
-        tags : {
-            // title: "Title, shown in sidebar",
-            // tag: "keyword of tag"
-            // cssclass: "set a individual class for each button"
-            // checkProp: "", // property of the tag to check if not equal to checkPropValue, i.e. "text"
-            // checkPropValue: "" // value compared to checkProp i.e. "" --> tagtype text(short): (tag.part("text") !== "")
-        },
-        // markup for buttons in sidebar
+        categories : [{
+            categoryname : "Objekteigenschaften",
+            tags : [{
+                                // "title" : "<b>Suche</b>: Vor interner Suche verstecken?",
+                                // "tag" : "object.uniqa_2015_notsearchable",
+                                // "cssclass" : "sidebarobject-uniqa_2015_notsearchable",
+                                // "checkProp": "check",
+                                // "checkPropValue": false
+            }]
+        }],
         template : '<button data-tag="{tag}" class="{cssclass}">{title}</button>'
     };
+
+    var taglist = [];
 
     // update validation when clsoing tagfill
     // compare and set/remove class "is-filled"
     function validateTag($elem) {
-        // check if validation config is set
-        if($elem.attr('data-checkprop') !== undefined) {
         // focus event is fired on tagfill close (gcn-plugin.js:715)
         // handle this once
         $('body').one('focus.objectpropertiesplugin', function (e) {
-                // get the page and tag obj after tagfill close to compare changes
-                var pageId = GCNPlugin.page.id();
-                GCN.page(pageId, function (page) {
-                    // get fresh tag object
-                    page.clear();
-                    GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
-                        console.log('run validation for ', pageId, tag.prop('id'));
-                        // get part and value to compare from html (write to html before)
-                        if (tag.part($elem.attr("data-checkprop")).toString() !== $elem.attr("data-checkpropvalue")) {
-                            // add class
-                            $elem.addClass('aloha-op-button-isfilled');
-                        } else {
-                            // not filled - remove class "is-filled"
-                            $elem.removeClass('aloha-op-button-isfilled');
-                        }
-                    });
-                });
+            // get the page and tag obj after tagfill close to compare changes
+            var pageId = GCNPlugin.page.id();
+            GCN.page(pageId, function (page){
+        // get fresh tag object
+        page.clear();
+        GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
+                    console.log('run validation for ', pageId, tag.prop('id'));
+                    // get part and value to compare from html (write to html before)
+                    if (tag.part($elem.attr("data-checkprop")).toString() !== $elem.attr("data-checkpropvalue")) {
+                        // add class
+                    $elem.addClass('aloha-op-button-isfilled');
+                    } else {
+                        // not filled - remove class "is-filled"
+                        $elem.removeClass('aloha-op-button-isfilled');
+                    }
+        });
             });
-        }
+        });
     }
 
     function openTag($elem) {
         var pageId = GCNPlugin.page.id();
-        GCN.page(pageId).tag($elem.attr("data-keyword"), function(tag){
-            //first we have to try to close any open tag fill
-            try {
-                GCNPlugin.closeLightbox();
-            } catch(err) {
-                //tag fill could not be closed because it was not open
-            }
-            //now we can open the desired object property as tag fill
-            console.log('opening tag fill for', pageId, tag.prop('id'));
-            // hook up validation
-            validateTag($elem); 
-            GCNPlugin.openTagFill(tag.prop('id'), pageId);
+        GCN.page(pageId, function (page) {
+            page.tag($elem.attr("data-keyword"), function(tag){
+                //first we have to try to close any open tag fill
+                try {
+                    GCNPlugin.closeLightbox();
+                } catch(err) {
+                    //tag fill could not be closed because it was not open
+                }
+                //now we can open the desired object property as tag fill
+                console.log('opening tag fill for', pageId, tag.prop('id'));
+                // hook up validation
+                validateTag($elem); 
+                GCNPlugin.openTagFill(tag.prop('id'), pageId);
+            });
         });
     }
 
@@ -88,55 +90,62 @@ define([
      * Have a look at http://www.aloha-editor.org/guides/sidebar.html
      */
     function prepareSidebar(sidebar) {
-        sidebar.addPanel({
-            id: 'aloha-objectproperties-panel',
-            title: i18n.t('sidebar.objectproperties.title'),
-            expanded: true,
-            activeOn: true,
-            content: '<div id="aloha-objectproperties-panel-content">\
-                        <fieldset id="aloha-objectproperties-panel-buttoncontainer">\
-                        </fieldset>\
-                      </div>',
-            onInit: function () {
-                var $buttoncontainer = $(this.content).find('#aloha-objectproperties-panel-buttoncontainer');
-                $buttoncontainer.on('click', '.aloha-op-button', function(){
-                    openTag($(this));
-                });
-                var pageId = GCNPlugin.page.id();
+        // add panel for each category
+        for (var j = 0; j < plugin._settings.categories.length; j++) {
+            sidebar.addPanel({
+                id: 'aloha-objectproperties-panel-' + plugin._settings.categories[j].categoryname,
+                title: plugin._settings.categories[j].categoryname,
+                expanded: true,
+                activeOn: true,
+                content: '<div id="aloha-objectproperties-panel-content-' + plugin._settings.categories[j].categoryname + '">\
+                            <fieldset id="aloha-objectproperties-panel-buttoncontainer-' + plugin._settings.categories[j].categoryname + '">\
+                            </fieldset>\
+                          </div>',
+                onInit: function () {
 
-                GCN.page(pageId).tags(function(tags) {
-                    $(plugin._settings.tags).each(function(){
-                        var display = false;
-                        var filled = false;
-                        for(var i = 0; i<tags.length; i++) {
-                            if(this.tag === tags[i]._name) {
-                                display = true;
-                                // check if validation config is set
-                                if(this.hasOwnProperty('checkProp')) {
-                                    if (tags[i].part(this.checkProp) !== this.checkPropValue) {
-                                        filled = true;
+                    var pageId = GCNPlugin.page.id();
+
+                    // compare all page tags to the tags in our set
+                    GCN.page(pageId).tags(function(tags) {
+                        $(Aloha.settings.plugins.objectproperties.config).each( function (category) {
+                            var categoryname = this.categoryname;
+                            $(this.tags).each( function (){
+                                var display = false;
+                                var filled = false;
+                                for(var i = 0; i<tags.length; i++) {
+                                    if(this.tag === tags[i]._name) {
+                                        // Object Property shall be editable in sidebar
+                                        display = true;
+                                        // get container
+                                        var $buttoncontainer = $(this.content).find('#aloha-objectproperties-panel-buttoncontainer-' + categoryname);
+                                        $buttoncontainer.on('click', '.aloha-op-button', function(){
+                                            openTag($(this));
+                                        });
+                                        if (tags[i].part(this.checkProp) !== this.checkPropValue) {
+                                            filled = true;
+                                        }
                                     }
                                 }
-                            }
-                        }
-                        if(display) {
-                            var html = formatTemplate(plugin._settings.template, this);
-                            var $button = $(html);
-                            $button
-                                .attr("data-keyword", this.tag)
-                                // add validation info
-                                .attr("data-checkprop", this.checkProp)
-                                .attr("data-checkpropvalue", this.checkPropValue);
-                            $button.addClass("aloha-op-button");
-                            if(filled){
-                                $button.addClass("aloha-op-button-isfilled");
-                            }
-                            $buttoncontainer.append($button);
-                        }
+                                if(display) {
+                                    var html = formatTemplate(plugin._settings.template, this);
+                                    var $button = $(html);
+                                    $button
+                                        .attr("data-keyword", this.tag)
+                                        // add validation info
+                                        .attr("data-checkprop", this.checkProp)
+                                        .attr("data-checkpropvalue", this.checkPropValue);
+                                    $button.addClass("aloha-op-button");
+                                    if(filled){
+                                        $button.addClass("aloha-op-button-isfilled");
+                                    }
+                                    $buttoncontainer.append($button);
+                                }
+                            });
+                        });
                     });
-                });
-            }
-        });
+                }
+            });
+        }
         sidebar.show();
     }
 


### PR DESCRIPTION
check if tag is filled an display in sidebar on pageload and on change:

Do this by setting config.settings.tags[i].ckeckProp to the tagpartname to get a value.
this is compared (!==) to config.settings.tags[i].checkPropValue. 
if the stringified value of the tagpart checkProp is not equal to checkPropValue a class will be added to the button in the sidebar. this results in a light green highlighting.

changes in function prepareSidebar.onInit --> initial validation

changes in openTag --> added event hookup by calling new function validateTag

added functio validateTag($elem) --> is called by openTag and also expects a jQuery Object of the element which is clicked on opening the tagfill. It will look for the attributes data-keyword, data-checkprop and data-checkpropvalue. 
These are set in prepareSidebar and by adding the properties "checkProp" and "checkPropValue" to config.tags (see comments at the variable defaults in objectproperties/lib/objectproperties-plugin.js)
